### PR TITLE
Add rebuild ghosts to nanobots research

### DIFF
--- a/prototypes/technology/nanobots.lua
+++ b/prototypes/technology/nanobots.lua
@@ -3,7 +3,12 @@ local tech1 = {
     name = 'nanobots',
     icon = '__Nanobots__/graphics/technology/tech-nanobots.png',
     icon_size = 128,
-    effects = {},
+    effects = {
+        {
+            type = "ghost-time-to-live",
+            modifier = 60 * 60 * 60 * 24 * 7
+        }
+    },
     prerequisites = {'logistics'},
     unit = {
         count = 30,


### PR DESCRIPTION
The ghost-time-to-live modifier is 0 initially, but set to a week after researching construction robotics, creating temporary ghosts of structures when they are destroyed. This revision will allow either research to set the modifier allowing structures to be automatically rebuilt.